### PR TITLE
Add calculator tests

### DIFF
--- a/frontend/app/routes/Calorie-calculator.test.tsx
+++ b/frontend/app/routes/Calorie-calculator.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import CalorieCalculator from './calorie-calculator'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+const renderCalculator = () =>
+  render(<MemoryRouter><CalorieCalculator /></MemoryRouter>)
+
+describe('CalorieCalculator', () => {
+  it('renders without crashing', () => {
+    renderCalculator()
+    expect(document.body).toBeTruthy()
+  })
+
+  it('displays the Calorie Calculator heading', () => {
+    renderCalculator()
+    expect(screen.getByText(/calorie calculator/i)).toBeTruthy()
+  })
+
+  it('displays the form fields', () => {
+    renderCalculator()
+    expect(screen.getByLabelText(/age/i)).toBeTruthy()
+    expect(screen.getByLabelText(/height/i)).toBeTruthy()
+    expect(screen.getByLabelText(/weight/i)).toBeTruthy()
+  })
+
+  it('displays sex selection buttons', () => {
+    renderCalculator()
+    expect(screen.getByText(/^male$/i)).toBeTruthy()
+    expect(screen.getByText(/^female$/i)).toBeTruthy()
+  })
+
+  it('displays activity level options', () => {
+    renderCalculator()
+    expect(screen.getByText(/inactive/i)).toBeTruthy()
+    expect(screen.getByText(/somewhat active/i)).toBeTruthy()
+    expect(screen.getByText(/very active/i)).toBeTruthy()
+  })
+
+  it('displays goal options', () => {
+    renderCalculator()
+    expect(screen.getByText(/lose weight/i)).toBeTruthy()
+    expect(screen.getByText(/maintain weight/i)).toBeTruthy()
+    expect(screen.getByText(/gain weight/i)).toBeTruthy()
+  })
+
+  it('calculate button is disabled when form is empty', () => {
+    renderCalculator()
+    const button = screen.getByText(/calculate calories/i)
+    expect(button.closest('button')).toHaveProperty('disabled', true)
+  })
+
+
+  it('shows results after filling out the form and submitting', () => {
+    renderCalculator()
+    fireEvent.change(screen.getByLabelText(/age/i), { target: { value: '25' } })
+    fireEvent.change(screen.getByLabelText(/height/i), { target: { value: '175' } })
+    fireEvent.change(screen.getByLabelText(/weight/i), { target: { value: '70' } })
+    fireEvent.click(screen.getByText(/^male$/i))
+    fireEvent.click(screen.getByText(/^inactive$/i))
+    fireEvent.click(screen.getByText(/^maintain weight$/i))
+    const form = document.querySelector('form')
+    fireEvent.submit(form!)
+    expect(screen.queryByText(/complete the form to see your personalized calorie recommendations/i)).toBeNull()
+  })
+
+})

--- a/frontend/app/routes/Fitness-log.test.tsx
+++ b/frontend/app/routes/Fitness-log.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import FitnessLog from './Fitness-log'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+const renderFitnessLog = () =>
+  render(<MemoryRouter><FitnessLog /></MemoryRouter>)
+
+describe('FitnessLog', () => {
+  it('renders without crashing', () => {
+    renderFitnessLog()
+    expect(document.body).toBeTruthy()
+  })
+
+  it('displays the Fitness Log heading', () => {
+    renderFitnessLog()
+    expect(screen.getByText(/fitness log/i)).toBeTruthy()
+  })
+
+  it('displays the daily summary card', () => {
+    renderFitnessLog()
+    expect(screen.getByText(/today's summary/i)).toBeTruthy()
+  })
+
+  it('displays default mock exercises on load', () => {
+    renderFitnessLog()
+    expect(screen.getByText(/bench press/i)).toBeTruthy()
+    expect(screen.getByText(/running/i)).toBeTruthy()
+    expect(screen.getByText(/squats/i)).toBeTruthy()
+  })
+
+  it('displays workout breakdown stats', () => {
+    renderFitnessLog()
+    expect(screen.getByText(/strength training/i)).toBeTruthy()
+    expect(screen.getAllByText(/cardio/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows add exercise form when Add Exercise button is clicked', () => {
+    renderFitnessLog()
+    fireEvent.click(screen.getByText(/add exercise/i))
+    expect(screen.getByText(/add new exercise/i)).toBeTruthy()
+  })
+
+  it('filters exercises when searching', () => {
+    renderFitnessLog()
+    const searchInput = screen.getByPlaceholderText(/search exercises/i)
+    fireEvent.change(searchInput, { target: { value: 'bench' } })
+    expect(screen.getByText(/bench press/i)).toBeTruthy()
+    expect(screen.queryByText(/running/i)).toBeNull()
+  })
+
+  it('removes an exercise when delete button is clicked', () => {
+    renderFitnessLog()
+    expect(screen.getByText(/squats/i)).toBeTruthy()
+    const deleteButtons = screen.getAllByRole('button', { name: '' })
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+    expect(screen.queryByText(/squats/i)).toBeNull()
+  })
+})

--- a/frontend/app/routes/Nutrition-log.test.tsx
+++ b/frontend/app/routes/Nutrition-log.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import NutritionLog from './Nutrition-log'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+const renderNutritionLog = () =>
+  render(<MemoryRouter><NutritionLog /></MemoryRouter>)
+
+describe('NutritionLog', () => {
+  it('renders without crashing', () => {
+    renderNutritionLog()
+    expect(document.body).toBeTruthy()
+  })
+
+  it('displays the Nutrition Log heading', () => {
+    renderNutritionLog()
+    expect(screen.getByText(/nutrition log/i)).toBeTruthy()
+  })
+
+  it('displays the daily summary card', () => {
+    renderNutritionLog()
+    expect(screen.getByText(/today's summary/i)).toBeTruthy()
+  })
+
+  it('displays default mock meals on load', () => {
+    renderNutritionLog()
+    expect(screen.getByText(/oatmeal with berries/i)).toBeTruthy()
+    expect(screen.getByText(/grilled chicken salad/i)).toBeTruthy()
+    expect(screen.getByText(/greek yogurt/i)).toBeTruthy()
+  })
+
+  it('displays macronutrient totals', () => {
+    renderNutritionLog()
+    expect(screen.getByText(/protein/i)).toBeTruthy()
+    expect(screen.getByText(/carbs/i)).toBeTruthy()
+    expect(screen.getByText(/fat/i)).toBeTruthy()
+  })
+
+  it('shows add meal form when Add Meal button is clicked', () => {
+    renderNutritionLog()
+    fireEvent.click(screen.getByText(/add meal/i))
+    expect(screen.getByText(/add new meal/i)).toBeTruthy()
+  })
+
+  it('filters meals when searching', () => {
+    renderNutritionLog()
+    const searchInput = screen.getByPlaceholderText(/search meals/i)
+    fireEvent.change(searchInput, { target: { value: 'oatmeal' } })
+    expect(screen.getByText(/oatmeal with berries/i)).toBeTruthy()
+    expect(screen.queryByText(/grilled chicken salad/i)).toBeNull()
+  })
+
+  it('removes a meal when delete button is clicked', () => {
+    renderNutritionLog()
+    expect(screen.getByText(/greek yogurt/i)).toBeTruthy()
+    const deleteButtons = screen.getAllByRole('button', { name: '' })
+    fireEvent.click(deleteButtons[deleteButtons.length - 1])
+    expect(screen.queryByText(/greek yogurt/i)).toBeNull()
+  })
+})

--- a/frontend/app/routes/dashboard.test.tsx
+++ b/frontend/app/routes/dashboard.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import Dashboard from './dashboard'
+
+// Mock useNavigate to avoid router context issues
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock('recharts', () => ({
+  AreaChart: ({ children }: any) => <div>{children}</div>,
+  BarChart: ({ children }: any) => <div>{children}</div>,
+  PieChart: ({ children }: any) => <div>{children}</div>,
+  Area: () => null, Bar: () => null, Pie: () => null, Cell: () => null,
+  XAxis: () => null, YAxis: () => null, CartesianGrid: () => null,
+  Tooltip: () => null, Legend: () => null,
+  ResponsiveContainer: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signOut: vi.fn().mockResolvedValue({}),
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } }
+      }),
+    },
+  },
+}))
+
+const renderDashboard = () =>
+  render(<MemoryRouter><Dashboard /></MemoryRouter>)
+
+
+describe('Dashboard', () => {
+  it('renders without crashing', () => {
+    renderDashboard()
+    expect(document.body).toBeTruthy()
+  })
+
+  it('displays the welcome message', () => {
+    renderDashboard()
+    expect(screen.getByText(/welcome back/i)).toBeTruthy()
+  })
+
+  it('displays calorie stats card', () => {
+    renderDashboard()
+    expect(screen.getByText(/calories today/i)).toBeTruthy()
+  })
+
+  it('displays workout stats card', () => {
+    renderDashboard()
+    expect(screen.getByText(/workouts this week/i)).toBeTruthy()
+  })
+
+  it('displays navigation feature cards', () => {
+    renderDashboard()
+    expect(screen.getByText(/calorie calculator/i)).toBeTruthy()
+  })
+
+  it('displays the recent activity section', () => {
+    renderDashboard()
+    expect(screen.getByText(/recent activity/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What changed
- Added calorie-calculator.test.tsx with 8 test cases

## Tests cover
- Renders without crashing
- Displays Calorie Calculator heading
- Displays all form fields (age, height, weight)
- Displays sex selection buttons (Male/Female)
- Displays all activity level options
- Displays all goal options (lose/maintain/gain)
- Calculate button is disabled when form is empty
- Results appear after form is submitted